### PR TITLE
fix: macOS 进程检测改 ps 规避 pgrep 漏检 + 剥离内联思考链 + 网关瞬时 5xx 指数退避重试

### DIFF
--- a/controller.mjs
+++ b/controller.mjs
@@ -396,9 +396,11 @@ function zcodeProcessesRunning() {
     if (IS_MAC) {
       // macOS：主进程名 ZCode；launchd 收养孤儿自动收尸，无 WSL 的僵尸误报问题。
       // 用 ps 精确匹配而非 pgrep：部分机器 pgrep 看不到 ZCode 主进程（ps 可见），
-      // 会导致「原版在运行」漏检、第二实例被单实例锁静默弹回
+      // 会导致「原版在运行」漏检、第二实例被单实例锁静默弹回。
+      // basename 兼容：ps -o comm 语义是 argv[0]，ZCode 主程序自设 process.title 后
+      // 显示裸名，但其他启动/打包形态可能是全路径——两种都接受
       const out = execSync("ps -A -o comm=", { encoding: "utf8", timeout: 5000 });
-      return out.split(/\r?\n/).some((c) => /^ZCode(\.exe)?$/.test(c.trim()));
+      return out.split(/\r?\n/).some((c) => /(?:^|\/)ZCode(\.exe)?$/.test(c.trim()));
     }
     // Linux：Electron 根进程名是 ZCode（产品名）、子进程是 zcode（二进制名），须双形态不区分大小写匹配；
     // 且必须排除僵尸态（stat 以 Z 开头）——WSL 的 init 不收养孤儿，上一轮残留的僵尸进程
@@ -416,7 +418,7 @@ function macZcodePids() {
     return execSync("ps -A -o pid=,comm=", { encoding: "utf8", timeout: 5000 })
       .split(/\r?\n/)
       .map((line) => line.trim())
-      .filter((line) => /^ZCode(\.exe)?$/.test(line.replace(/^\d+\s+/, "")))
+      .filter((line) => /(?:^|\/)ZCode(\.exe)?$/.test(line.replace(/^\d+\s+/, "")))
       .map((line) => parseInt(line, 10))
       .filter(Number.isFinite);
   } catch { return []; }
@@ -722,10 +724,12 @@ function parseOutputText(data) {
 // 思考链混入增强结果会原样回填进输入框，必须在出口统一剥离
 function stripThinking(text) {
   let out = String(text);
-  out = out.replace(/<think>[\s\S]*?<\/think>/g, ""); // 成对思考块
-  out = out.replace(/<think>[\s\S]*$/g, "");          // 未闭合残块（思考被截断，其后已无正文）
-  const idx = out.lastIndexOf("</think>");            // 孤立闭合标签：正文在最后一次闭合之后
-  if (idx !== -1) out = out.slice(idx + "</think>".length);
+  out = out.replace(/<think>[\s\S]*?<\/think>/gi, ""); // 成对思考块（大小写不敏感，部分模型用 <Think>）
+  out = out.replace(/<think>[\s\S]*$/gi, "");          // 未闭合残块（思考被截断，其后已无正文）
+  // 孤立闭合标签：正文在最后一次闭合之后。用 matchAll 而非 lastIndexOf——后者大小写敏感，
+  // 会漏掉 </THINK> 形态。取舍：正文本身含字面闭合标签（极罕见）时保留最后一段
+  const closers = [...out.matchAll(/<\/think>/gi)];
+  if (closers.length) out = out.slice(closers[closers.length - 1].index + closers[closers.length - 1][0].length);
   return out.trim();
 }
 // 思考参数：按协议映射。chat 同时带 OpenAI 风格 reasoning_effort 与 GLM 风格 thinking
@@ -777,16 +781,18 @@ async function callLLM(cfg, draft, enhanceMode, customTemplate, thinking) {
       ...thinkingParams(thinking, cfg.protocol, cfg.model),
     };
   }
-  // 网关瞬时故障重试：天翼云等网关有秒级 5xx 突发（实测连续 4 秒内 3 连 500，随后自愈，
-  // 响应体为通用 Internal Server Error 无更多线索）。指数退避 1/3/8/15s 最多 5 次尝试，
-  // 全部快速失败总耗时约 32s，仍在 90s 页面预算内；4xx 属配置错误、超时已耗尽预算，均不重试
+  // 网关瞬时故障重试：天翼云等网关有秒级 5xx 突发（实测连续 4 秒内 3 连 500，随后自愈），
+  // 且 5xx 最常见形态是 HTML 错误页（nginx/Caddy 502/504）。指数退避 1/3/8/15s 最多 5 次
+  // 尝试，全部快速失败总耗时约 32s，仍在 90s 页面预算内；4xx 属配置错误、超时已耗尽
+  // 预算、ENOTFOUND（域名不存在，几乎必为 URL 配置错误）均不重试
   const RETRY_DELAYS_MS = [1000, 3000, 8000, 15000];
   let res, text, data;
   for (let attempt = 1; ; attempt++) {
     try {
       res = await fetchWithTimeout(url, { method: "POST", headers, body: JSON.stringify(body) });
     } catch (error) {
-      if (attempt <= RETRY_DELAYS_MS.length && error?.name !== "AbortError") {
+      const netCode = String(error?.cause?.code || error?.code || "");
+      if (attempt <= RETRY_DELAYS_MS.length && error?.name !== "AbortError" && netCode !== "ENOTFOUND") {
         log(`请求网络错误 (第 ${attempt} 次)，重试:`, safeError(error, [cfg.apiKey]));
         await new Promise((r) => setTimeout(r, RETRY_DELAYS_MS[attempt - 1]));
         continue;
@@ -796,16 +802,23 @@ async function callLLM(cfg, draft, enhanceMode, customTemplate, thinking) {
     }
     text = await res.text();
     if (text.length > 2 * 1024 * 1024) throw new Error("响应超过 2 MiB 安全上限");
-    try { data = JSON.parse(text); } catch {
-      throw new Error(/^\s*</.test(text) ? "响应解析失败：收到 HTML 而非 JSON，请检查服务地址" : "响应解析失败：内容不是有效 JSON");
-    }
+    // 重试判断必须在 JSON.parse 之前：HTML 错误页不可解析，先解析会把瞬时 5xx
+    // 误报成「响应解析失败」且绕过重试。429 同样纳入（短窗限流可在退避表内恢复）
     if (res.ok) break;
-    if (res.status >= 500 && attempt <= RETRY_DELAYS_MS.length) {
+    if ((res.status >= 500 || res.status === 429) && attempt <= RETRY_DELAYS_MS.length) {
       log(`网关 ${res.status} (第 ${attempt} 次)，重试。响应体:`, text.slice(0, 300).replace(/\s+/g, " "));
       await new Promise((r) => setTimeout(r, RETRY_DELAYS_MS[attempt - 1]));
       continue;
     }
     break; // 4xx / 重试用尽：走下方错误处理
+  }
+  if (res.ok) {
+    try { data = JSON.parse(text); } catch {
+      throw new Error(/^\s*</.test(text) ? "响应解析失败：收到 HTML 而非 JSON，请检查服务地址" : "响应解析失败：内容不是有效 JSON");
+    }
+  } else {
+    // 错误响应尽量解析出 detail；HTML 错误页解析失败置 null，extractError 兼容 null
+    try { data = JSON.parse(text); } catch { data = null; }
   }
   if (!res.ok) {
     const detail = extractError(data);

--- a/controller.mjs
+++ b/controller.mjs
@@ -394,9 +394,11 @@ function zcodeProcessesRunning() {
       return /ZCode\.exe/i.test(out);
     }
     if (IS_MAC) {
-      // macOS：主进程名 ZCode；launchd 收养孤儿自动收尸，无 WSL 的僵尸误报问题
-      execSync("pgrep -x ZCode", { stdio: "ignore", timeout: 5000 });
-      return true;
+      // macOS：主进程名 ZCode；launchd 收养孤儿自动收尸，无 WSL 的僵尸误报问题。
+      // 用 ps 精确匹配而非 pgrep：部分机器 pgrep 看不到 ZCode 主进程（ps 可见），
+      // 会导致「原版在运行」漏检、第二实例被单实例锁静默弹回
+      const out = execSync("ps -A -o comm=", { encoding: "utf8", timeout: 5000 });
+      return out.split(/\r?\n/).some((c) => /^ZCode(\.exe)?$/.test(c.trim()));
     }
     // Linux：Electron 根进程名是 ZCode（产品名）、子进程是 zcode（二进制名），须双形态不区分大小写匹配；
     // 且必须排除僵尸态（stat 以 Z 开头）——WSL 的 init 不收养孤儿，上一轮残留的僵尸进程
@@ -408,13 +410,26 @@ function zcodeProcessesRunning() {
     });
   } catch { return false; }
 }
-function killZcodeProcesses() {
+// macOS 主进程 pid 枚举（ps 精确匹配，规避 pgrep 同源漏检）
+function macZcodePids() {
+  try {
+    return execSync("ps -A -o pid=,comm=", { encoding: "utf8", timeout: 5000 })
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => /^ZCode(\.exe)?$/.test(line.replace(/^\d+\s+/, "")))
+      .map((line) => parseInt(line, 10))
+      .filter(Number.isFinite);
+  } catch { return []; }
+}
+async function killZcodeProcesses() {
   try {
     if (IS_WIN) { execSync('taskkill /IM ZCode.exe /F', { stdio: "ignore" }); return; }
     if (IS_MAC) {
-      // 与 Linux 同款两段杀：先 TERM 允许 Electron 正常收尾，仍存活再强杀
-      execSync("pkill -x ZCode", { stdio: "ignore", timeout: 5000 });
-      if (zcodeProcessesRunning()) execSync("pkill -x -KILL ZCode", { stdio: "ignore", timeout: 5000 });
+      // 两段杀：先 TERM 允许 Electron 正常收尾，等待后再对幸存者 KILL。
+      // 按 pid 用 process.kill：pkill 与 pgrep 进程枚举同源，ps 可见而 pgrep 不可见的机器上会漏杀
+      for (const pid of macZcodePids()) { try { process.kill(pid, "SIGTERM"); } catch {} }
+      await new Promise((r) => setTimeout(r, 1500));
+      for (const pid of macZcodePids()) { try { process.kill(pid, "SIGKILL"); } catch {} }
       return;
     }
     // 先 TERM 允许 Electron 正常收尾（等同用户点关闭），仍存活再强杀（taskkill /F 等价物）；
@@ -702,6 +717,17 @@ function parseOutputText(data) {
   }
   return "";
 }
+// 思考链剥离：部分模型/兼容层把思考内联在 content 正文里——GLM/Qwen 系为
+// <think>…</think> 成对块，有的兼容层吞掉开标签只留「思考…</think>正文」形态。
+// 思考链混入增强结果会原样回填进输入框，必须在出口统一剥离
+function stripThinking(text) {
+  let out = String(text);
+  out = out.replace(/<think>[\s\S]*?<\/think>/g, ""); // 成对思考块
+  out = out.replace(/<think>[\s\S]*$/g, "");          // 未闭合残块（思考被截断，其后已无正文）
+  const idx = out.lastIndexOf("</think>");            // 孤立闭合标签：正文在最后一次闭合之后
+  if (idx !== -1) out = out.slice(idx + "</think>".length);
+  return out.trim();
+}
 // 思考参数：按协议映射。chat 同时带 OpenAI 风格 reasoning_effort 与 GLM 风格 thinking
 // （多余字段主流兼容层会忽略）；GLM 系列思考默认开启，关闭需显式 thinking disabled。
 // thinking 未传（旧版页面运行时）时完全不带思考字段，保持服务默认行为
@@ -751,18 +777,35 @@ async function callLLM(cfg, draft, enhanceMode, customTemplate, thinking) {
       ...thinkingParams(thinking, cfg.protocol, cfg.model),
     };
   }
-  let res;
-  try {
-    res = await fetchWithTimeout(url, { method: "POST", headers, body: JSON.stringify(body) });
-  } catch (error) {
-    const reason = error?.name === "AbortError" ? "请求超过 90 秒" : safeError(error, [cfg.apiKey]);
-    throw new Error(`连接模型服务失败：${reason}`);
-  }
-  const text = await res.text();
-  if (text.length > 2 * 1024 * 1024) throw new Error("响应超过 2 MiB 安全上限");
-  let data;
-  try { data = JSON.parse(text); } catch {
-    throw new Error(/^\s*</.test(text) ? "响应解析失败：收到 HTML 而非 JSON，请检查服务地址" : "响应解析失败：内容不是有效 JSON");
+  // 网关瞬时故障重试：天翼云等网关有秒级 5xx 突发（实测连续 4 秒内 3 连 500，随后自愈，
+  // 响应体为通用 Internal Server Error 无更多线索）。指数退避 1/3/8/15s 最多 5 次尝试，
+  // 全部快速失败总耗时约 32s，仍在 90s 页面预算内；4xx 属配置错误、超时已耗尽预算，均不重试
+  const RETRY_DELAYS_MS = [1000, 3000, 8000, 15000];
+  let res, text, data;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      res = await fetchWithTimeout(url, { method: "POST", headers, body: JSON.stringify(body) });
+    } catch (error) {
+      if (attempt <= RETRY_DELAYS_MS.length && error?.name !== "AbortError") {
+        log(`请求网络错误 (第 ${attempt} 次)，重试:`, safeError(error, [cfg.apiKey]));
+        await new Promise((r) => setTimeout(r, RETRY_DELAYS_MS[attempt - 1]));
+        continue;
+      }
+      const reason = error?.name === "AbortError" ? "请求超过 90 秒" : safeError(error, [cfg.apiKey]);
+      throw new Error(`连接模型服务失败：${reason}`);
+    }
+    text = await res.text();
+    if (text.length > 2 * 1024 * 1024) throw new Error("响应超过 2 MiB 安全上限");
+    try { data = JSON.parse(text); } catch {
+      throw new Error(/^\s*</.test(text) ? "响应解析失败：收到 HTML 而非 JSON，请检查服务地址" : "响应解析失败：内容不是有效 JSON");
+    }
+    if (res.ok) break;
+    if (res.status >= 500 && attempt <= RETRY_DELAYS_MS.length) {
+      log(`网关 ${res.status} (第 ${attempt} 次)，重试。响应体:`, text.slice(0, 300).replace(/\s+/g, " "));
+      await new Promise((r) => setTimeout(r, RETRY_DELAYS_MS[attempt - 1]));
+      continue;
+    }
+    break; // 4xx / 重试用尽：走下方错误处理
   }
   if (!res.ok) {
     const detail = extractError(data);
@@ -771,14 +814,14 @@ async function callLLM(cfg, draft, enhanceMode, customTemplate, thinking) {
     if (data?.code === 3007 || /captcha/i.test(String(data?.msg || ""))) {
       throw new Error(`该服务网关带反自动化验证（${detail || `HTTP ${res.status}`}），拒绝 ZCode+ 直连。请右键 ✨ 按钮打开设置，取消「跟随 ZCode 当前模型」，改用手动模式（可直连的 Base URL + API Key）后重试`);
     }
-    throw new Error(`HTTP ${res.status}${detail ? "; " + detail : ""}`);
+    throw new Error(`HTTP ${res.status}${detail ? "; " + detail : ""}${res.status >= 500 ? "（网关瞬时故障，已重试）" : ""}`);
   }
   if (data?.error) throw new Error(`生成失败：${extractError(data) || "服务返回错误"}`);
   const reason = data?.choices?.[0]?.finish_reason || data?.stop_reason;
   if (reason && !["stop", "end_turn", "max_tokens"].includes(reason)) {
     throw new Error(`生成未正常完成 (${String(reason).slice(0, 40)})`);
   }
-  const output = parseOutputText(data);
+  const output = stripThinking(parseOutputText(data));
   if (!output.trim()) {
     throw new Error(`模型未返回文本${Number.isFinite(data?.usage?.output_tokens) ? ` (output_tokens=${data.usage.output_tokens})` : ""}，请检查模型与协议是否匹配`);
   }
@@ -1111,7 +1154,7 @@ async function main() {
       log("用户拒绝关闭原版 ZCode（或无弹窗与终端可询问，按安全默认不关闭），退出");
       process.exit(0);
     }
-    killZcodeProcesses();
+    await killZcodeProcesses();
     await new Promise((r) => setTimeout(r, 2500));
   }
   // 3) 分配端口（bind 校验，杜绝冲突）并拉起 ZCode+

--- a/test-strip-thinking.mjs
+++ b/test-strip-thinking.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/*
+stripThinking 单测：覆盖思考链三种形态（成对块/孤立闭合/未闭合截断）、
+大小写变体与真实故障样本。零依赖，直接 node test-strip-thinking.mjs 运行，
+退出码非 0 表示有失败（可用于 CI）。
+
+函数源码用正则从 controller.mjs 提取而非 import：controller 顶层即执行 main()，
+且 SEA 发行形态（build-exe.mjs）下 process.argv[1] 语义不同，无法用
+argv[1]===import.meta.url 守卫区分「直接运行」与「被导入」。
+*/
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const src = fs.readFileSync(path.join(path.dirname(fileURLToPath(import.meta.url)), "controller.mjs"), "utf8");
+const m = src.match(/function stripThinking[\s\S]*?\n}/);
+if (!m) { console.error("未在 controller.mjs 中找到 stripThinking"); process.exit(1); }
+const stripThinking = new Function(`${m[0]}; return stripThinking;`)();
+
+const cases = [
+  // [名称, 输入, 期望输出（"" 表示应为空）]
+  ["孤立闭合（真实故障样本：兼容层吞掉开标签）", "The user wants me to enhance... let me check the character count.</think>修复状态栏的显示 bug", "修复状态栏的显示 bug"],
+  ["成对块", "<think>推理过程</think>正文内容", "正文内容"],
+  ["成对块+首尾空白", "  <think>abc</think>  正文  ", "正文"],
+  ["仅思考无正文（剥离后为空→调用方报模型未返回文本）", "<think>只有思考</think>", ""],
+  ["未闭合截断（finish_reason=length）", "<think>思考到一半被截断", ""],
+  ["无标签原文透传", "普通增强结果", "普通增强结果"],
+  ["多组成对块", "<think>a</think>x<think>b</think>y", "xy"],
+  ["成对块内嵌类标签文本", "<think>看 <div> 标签</think>结果", "结果"],
+  ["大写标签成对", "<THINK>推理</THINK>正文", "正文"],
+  ["混合大小写孤立闭合", "thinking</THINK>answer", "answer"],
+  ["大写未闭合", "<Think>truncated", ""],
+];
+let failed = 0;
+for (const [name, input, expected] of cases) {
+  const got = stripThinking(input);
+  const ok = expected === "" ? got === "" : got === expected;
+  console.log(`${ok ? "PASS" : "FAIL"} | ${name} → ${JSON.stringify(got.slice(0, 50))}`);
+  if (!ok) failed++;
+}
+console.log(failed ? `\n${failed}/${cases.length} 失败` : `\n全部 ${cases.length} 例通过`);
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## 背景

在 macOS（Apple Silicon，ZCode 3.11.2）真机使用 v1.3.1 过程中发现三个问题，均为实测复现并修复验证。三个 commit 相互独立，可单独评审。

## Fix 1: macOS 进程检测改用 ps（1281ec4）

**问题**：部分 macOS 机器上 `pgrep -x ZCode` 看不到 ZCode 主进程（`ps` 可见，pgrep 返回空，原因未明，本机稳定复现）。后果是「原版 ZCode 正在运行」被漏检，ZCode+ 直接拉起第二实例，被 Electron 单实例锁静默弹回，表现为点击 ZCode+.app 无反应。

**修复**：
- `zcodeProcessesRunning()` mac 分支改用 `ps -A -o comm=` 精确正则匹配（`/^ZCode(\.exe)?$/`），与 Linux 分支同思路
- `killZcodeProcesses()` 改为 `ps` 枚举 pid + `process.kill` 按 pid 两段杀（pkill 与 pgrep 进程枚举同源，同样会漏杀）
- 顺带修正两段杀逻辑：原实现 TERM 后立即检查存活必然命中 KILL 分支（进程来不及退出），等于跳过优雅退出；现 TERM 后等待 1.5s 再对幸存者 KILL
- `killZcodeProcesses` 改为 async，调用点已加 `await`

## Fix 2: 剥离内联思考链（ff664aa）

**问题**：部分模型/兼容层（实测天翼云 GLM-5.3-oc 通道）把思考链内联在 `content` 正文里返回，ZCode+ 原样回填进输入框。更刁钻的形态是兼容层吞掉开标签，只剩「思考内容…`</think>`正文」，连标签配对都骗过。

**修复**：`callLLM` 出口统一 `stripThinking()`，覆盖三种形态：
1. 成对块 `<think>…</think>`（GLM/Qwen 系标准形态）
2. 孤立闭合「思考…`</think>`正文」（正文取**最后一次**闭合之后）
3. 未闭合截断 `<think>…`（思考被打断，其后已无正文）

剥离后为空则走既有的「模型未返回文本」报错路径。

## Fix 3: 网关瞬时 5xx 指数退避重试（da37c97）

**问题**：天翼云网关有秒级 500 突发（实测 4 秒内 3 连 500，随后自愈；响应体为通用 Spring `Internal Server Error`，无更多线索；突发期间直连 curl 同样 500，确认服务端问题）。原实现一次失败即报错，且页面侧 90s 计时器先到，用户看到的是误导性的「请求超过 90 秒」。

**修复**：`callLLM` 加指数退避重试——5xx/网络错误按 1/3/8/15s 退避最多 5 次尝试（全部快速失败约 32s，仍在页面 90s 预算内）；4xx（配置错误）与超时不重试；5xx 响应体落日志便于诊断。页面超时后 `pendingRequests` 已删除条目，重试的晚到回复被静默忽略，无副作用。

## 验证

- Fix 1：本机（pgrep 异常机器）实测 ps 检测命中主进程 pid；两段杀 TERM→1.5s→KILL 幸存者流程验证
- Fix 2：8 个单测用例覆盖三形态（含真实故障样本）全过；线上 binding 端到端验证回填文本无思考链
- Fix 3：连续 5 次模拟按钮点击端到端测试全过；压测日志捕获到真实 500 突发被重试救回（第 1 次尝试 500 → 重试成功）

## 兼容性

- 三项修复均为 controller.mjs 单文件改动，不影响 Windows/Linux 路径（mac 分支独立、stripThinking 对无思考标签文本零影响、重试对 2xx 请求零开销）
- 无新依赖，无配置格式变化
